### PR TITLE
Added api for getting team data from the database

### DIFF
--- a/src/counsellingTeam/models.py
+++ b/src/counsellingTeam/models.py
@@ -7,7 +7,7 @@ class Team(models.Model):
         ('UG', 'UG'),
         ('PG', "PG"),
     )
-    YEAR_CHOICES = [(x, x) for x in range(int(datetime.datetime.now().year), 2007, -1)]
+    YEAR_CHOICES = [(str(x), str(x)) for x in range(int(datetime.datetime.now().year), 2007, -1)]
 
     year = models.CharField(max_length=10, choices=YEAR_CHOICES)
     team_type = models.CharField(max_length=4, choices=TEAM_CHOICES)

--- a/src/counsellingTeam/serializer.py
+++ b/src/counsellingTeam/serializer.py
@@ -1,0 +1,40 @@
+from rest_framework import serializers
+
+from oauth.models import UserProfile, SocialLink
+from .models import Team
+
+
+class UserProfileSerializer(serializers.ModelSerializer):
+    name = serializers.SerializerMethodField()
+    email = serializers.SerializerMethodField()
+    skills_as_list = serializers.SerializerMethodField()
+    social_links = serializers.SerializerMethodField()
+
+    class Meta:
+        model = UserProfile
+        exclude = ['user']
+
+    def get_name(self, obj):
+        return obj.user.get_full_name()
+
+    def get_email(self, obj):
+        return obj.user.email
+
+    def get_skills_as_list(self, obj):
+        return obj.skills_as_list
+
+    def get_social_links(self, obj):
+        handels = SocialLink.objects.filter(user=obj.user)
+        data = {}
+        for handel in handels:
+            data[handel.social_media] = handel.link
+
+
+class TeamSerializer(serializers.ModelSerializer):
+    student_heads = UserProfileSerializer(many=True)
+    student_assistant_heads = UserProfileSerializer(many=True)
+    student_guides = UserProfileSerializer(many=True)
+
+    class Meta:
+        model = Team
+        exclude = ['id']

--- a/src/counsellingTeam/urls.py
+++ b/src/counsellingTeam/urls.py
@@ -1,0 +1,11 @@
+from django.conf.urls import url, include
+from rest_framework import routers
+
+from .views import TeamDisplayViewSet
+
+router = routers.SimpleRouter()
+router.register(r'team', TeamDisplayViewSet, basename='Team')
+
+urlpatterns = [
+    url(r'^api/', include((router.urls))),
+]

--- a/src/counsellingTeam/views.py
+++ b/src/counsellingTeam/views.py
@@ -1,3 +1,17 @@
 # from django.shortcuts import render
+from rest_framework import viewsets
 
-# Create your views here.
+from .models import Team
+from .serializer import TeamSerializer
+
+
+class TeamDisplayViewSet(viewsets.ReadOnlyModelViewSet):
+    serializer_class = TeamSerializer
+
+    def get_queryset(self):
+        year = self.request.GET.get('year')
+        team_type = self.request.GET.get('team_type').upper()
+        print(year, team_type)
+        queryset = Team.objects.filter(year=year, team_type=team_type)
+        print(len(queryset))
+        return queryset

--- a/src/gymkhana/urls.py
+++ b/src/gymkhana/urls.py
@@ -46,6 +46,7 @@ urlpatterns = [
     url(r'^forum/', include('forum.urls')),
     url(r'^forum/api/', include('forum.api.urls')),
     url(r'^konnekt/', include('konnekt.urls')),
+    url(r'^counsellingTeam/', include('counsellingTeam.urls')),
     url(r'^festivals/', include('festivals.urls', namespace='festivals')),
     path('', include('social_django.urls', namespace='social')),
     url(r'^', include('main.urls')),


### PR DESCRIPTION
### Description
Added api for getting team data from the database

api allows get request on url
/counsellingTeam/api/team/
and take parameters year and team_type

response ss

![2020-06-14](https://user-images.githubusercontent.com/51405571/84595926-52ff6800-ae78-11ea-9606-807e6c35f6e5.png)

### Type of Change:
**Delete irrelevant options.**

- Code
- Quality Assurance
- User Interface
- Documentation
- Test

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update (software upgrade on readme file)
- New feature (non-breaking change which adds functionality pre-approved by maintainers)

### Checklist:
**Delete irrelevant options.**

- [ ] My PR follows the style guidelines of this project
- [ ] I have commented my code or provided relevant documentation
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective
- [ ] New and existing unit tests pass locally with my changes